### PR TITLE
Hotfix/0.2.13

### DIFF
--- a/application/controllers/api/money_tracker.php
+++ b/application/controllers/api/money_tracker.php
@@ -269,9 +269,9 @@ class Money_Tracker extends REST_Controller{
             unset($where_array['confirm']);
         }
         if(!empty($where_array['min_value']))
-            $where_stmt["entries.value >="] = $where_array["min_value"];
+            $where_stmt["entries.entry_value >="] = $where_array["min_value"];
         if(!empty($where_array['max_value']))
-            $where_stmt["entries.value <="] = $where_array["max_value"];
+            $where_stmt["entries.entry_value <="] = $where_array["max_value"];
         if(!empty($where_array['group']))
             $where_stmt["account_types.account_group"] = $where_array["group"];
         if(!empty($where_array['tags'])){

--- a/system/core/Common.php
+++ b/system/core/Common.php
@@ -254,7 +254,8 @@ if ( ! function_exists('get_config'))
 			}
 		}
 
-		return $_config[0] =& $config;
+		$_config[0] =& $config;
+		return $_config[0];
 	}
 }
 


### PR DESCRIPTION
- Corrected forgotten about update to to searching the `entries.entry_value` column when the column name was updated.
- Corrected bug that occurs in the _CodeIgniter_ core code that causes errors to appear when using PHP 5.6.